### PR TITLE
A bit less tight POST form checking.

### DIFF
--- a/src/BeeHub_Auth.php
+++ b/src/BeeHub_Auth.php
@@ -333,16 +333,15 @@ class BeeHub_Auth {
       $_POST[ $postField ] !== $this->getPostAuthCode()
     ){
       $_SESSION[ $postAuthAttempts ]++;
-      if ( $_SESSION[ $postAuthAttempts ] >= 5 ) {
+      if ( $_SESSION[ $postAuthAttempts ] >= 500 ) {
+        // After 500 failed attempts, we unset the key, so a new one should be generated. This is to prevent brute force attempts.
         unset( $_SESSION[ self::$SESSION_KEY ] );
         $_SESSION[ $postAuthAttempts ] = 0;
       }
       return false;
     }
 
-    unset( $_SESSION[ self::$SESSION_KEY ] );
     $_SESSION[ $postAuthAttempts ] = 0;
-
     return true;
   }
 


### PR DESCRIPTION
Changing POST keys could be a problem with multiple screen open. Now, the POST key stays the same for the whole session, unless 500 failed attempts were made.
